### PR TITLE
fix: correct activities typo in Categories

### DIFF
--- a/app/components/navbar/Categories.tsx
+++ b/app/components/navbar/Categories.tsx
@@ -58,7 +58,7 @@ export const categories = [
     {
       label: 'Skiing',
       icon: FaSkiing,
-      description: 'This property has skiing activies!'
+      description: 'This property has skiing activities!'
     },
     {
       label: 'Castles',


### PR DESCRIPTION
## Summary
- correct "activies" typo in Categories component

## Testing
- `git status --short`
